### PR TITLE
Fix splash screen still showing when `false`

### DIFF
--- a/source/main.c
+++ b/source/main.c
@@ -399,12 +399,12 @@ s32 main(s32 argc, const char* argv[])
 		return (-1);
 	}
 
+	// Load application settings
+	load_app_settings(&gcm_config);
+
 	// Splash screen logo (fade-in)
 	if (gcm_config.doAni)
 		drawSplashLogo(1);
-
-	// Load application settings
-	load_app_settings(&gcm_config);
 
 	// Unpack application data on first run
 	if (strncmp(gcm_config.app_ver, GOLDCHEATS_VERSION, sizeof(gcm_config.app_ver)) != 0)


### PR DESCRIPTION
Settings must be loaded before check